### PR TITLE
Resolve org.eclipse.jgit.lib.ObjectIdRef

### DIFF
--- a/src/clj_jgit/internal.clj
+++ b/src/clj_jgit/internal.clj
@@ -2,7 +2,7 @@
   (:import
     [org.eclipse.jgit.revwalk RevWalk RevCommit RevCommitList]
     [org.eclipse.jgit.treewalk TreeWalk]
-    [org.eclipse.jgit.lib ObjectId]
+    [org.eclipse.jgit.lib ObjectId ObjectIdRef]
     [org.eclipse.jgit.api Git]
     [org.eclipse.jgit.transport RefSpec]))
 
@@ -43,6 +43,12 @@
   (resolve-object
     ^org.eclipse.jgit.lib.ObjectId [commit-ish ^Git repo]
     commit-ish))
+
+(extend-type ObjectIdRef
+  Resolvable
+  (resolve-object
+    ^org.eclipse.jgit.lib.ObjectId [commit-ish ^Git repo]
+    (.getObjectId commit-ish)))
 
 (extend-type Git
   Resolvable


### PR DESCRIPTION
Required for merging the first advertised ref at the end of git-clone-full.
The advertised refs of a FetchResult are of type ObjectIdRef.
