### PR TITLE
Add line contents to the git-blame output, mimicking "git blame" command

### DIFF
--- a/src/clj_jgit/porcelain.clj
+++ b/src/clj_jgit/porcelain.clj
@@ -672,6 +672,7 @@
                :commit commit
                :committer (util/person-ident (.getSourceCommitter blame num))
                :line (.getSourceLine blame num)
+               :line-contents (-> blame .getResultContents (.getString num))
                :source-path (.getSourcePath blame num)}))
           (blame-seq [num]
             (when-let [cur (blame-line num)]


### PR DESCRIPTION
I think it will be nice to be able to get all the information "git blame" command outputs via one 'git-blame' call, without resorting to getting specific file explicitly.
