### PR TITLE
refactor with-identity

### DIFF
--- a/docs/uberdoc.html
+++ b/docs/uberdoc.html
@@ -3506,19 +3506,22 @@ net.brehaut.ClojureTools = (function (SH) {
                         (.getBytes passphrase)))))))</pre></td></tr><tr><td class="docs">
 </td><td class="codes"><pre class="brush: clojure">(SshSessionFactory/setInstance jsch-factory)</pre></td></tr><tr><td class="docs"><p>Creates an identity to use for SSH authentication.</p>
 </td><td class="codes"><pre class="brush: clojure">(defmacro with-identity
-  [{:keys [name private public passphrase options exclusive identities]
-    :or {name &quot;jgit-identity&quot;
-         passphrase &quot;&quot;
-         options {&quot;StrictHostKeyChecking&quot; &quot;no&quot;}
-         exclusive false}} &amp; body]
-  `(binding [*ssh-identity-name* ~name
-             *ssh-prvkey* ~private
-             *ssh-pubkey* ~public
-             *ssh-identities* ~identities
-             *ssh-passphrase* ~passphrase
-             *ssh-session-config* ~options
-             *ssh-exclusive-identity* ~exclusive]
-     ~@body))</pre></td></tr><tr><td class="docs">
+  [config &amp; body]
+  `(let [name# (get ~config :name &quot;jgit-identity&quot;)
+         private# (get ~config :private)
+         public# (get ~config :public)
+         passphrase# (get ~config :passphrase &quot;&quot;)
+         options# (get ~config :options {&quot;StrictHostKeyChecking&quot; &quot;no&quot;})
+         exclusive# (get ~config :exclusive false)
+         identities# (get ~config :identities)]
+     (binding [*ssh-identity-name* name#
+               *ssh-prvkey* private#
+               *ssh-pubkey* public#
+               *ssh-identities* identities#
+               *ssh-passphrase* passphrase#
+               *ssh-session-config* options#
+               *ssh-exclusive-identity* exclusive#]
+       ~@body)))</pre></td></tr><tr><td class="docs">
 </td><td class="codes"><pre class="brush: clojure">(defn submodule-walk
   ([repo]
      (-&gt;&gt; (submodule-walk (.getRepository repo) 0)

--- a/src/clj_jgit/porcelain.clj
+++ b/src/clj_jgit/porcelain.clj
@@ -488,19 +488,22 @@
 
 (defmacro with-identity
   "Creates an identity to use for SSH authentication."
-  [{:keys [name private public passphrase options exclusive identities]
-    :or {name "jgit-identity"
-         passphrase ""
-         options {"StrictHostKeyChecking" "no"}
-         exclusive false}} & body]
-  `(binding [*ssh-identity-name* ~name
-             *ssh-prvkey* ~private
-             *ssh-pubkey* ~public
-             *ssh-identities* ~identities
-             *ssh-passphrase* ~passphrase
-             *ssh-session-config* ~options
-             *ssh-exclusive-identity* ~exclusive]
-     ~@body))
+  [config & body]
+  `(let [name# (get ~config :name "jgit-identity")
+         private# (get ~config :private)
+         public# (get ~config :public)
+         passphrase# (get ~config :passphrase "")
+         options# (get ~config :options {"StrictHostKeyChecking" "no"})
+         exclusive# (get ~config :exclusive false)
+         identities# (get ~config :identities)]
+     (binding [*ssh-identity-name* name#
+               *ssh-prvkey* private#
+               *ssh-pubkey* public#
+               *ssh-identities* identities#
+               *ssh-passphrase* passphrase#
+               *ssh-session-config* options#
+               *ssh-exclusive-identity* exclusive#]
+       ~@body)))
 
 (defn submodule-walk
   ([repo]

--- a/test/clj_jgit/test/querying.clj
+++ b/test/clj_jgit/test/querying.clj
@@ -62,49 +62,53 @@
 
   (testing "commit-info"
     (read-only-repo
-      (are 
-        [commit-ish info] (= info (-> commit-ish
-                                    ((partial find-rev-commit repo (new-rev-walk repo))) 
-                                    ((partial commit-info repo))
-                                    (dissoc :repo :raw :time)))
-        "38dd57264cf5c05fb77211c8347d1f16e4474623" {:changed_files 
-                                                    [[".gitignore" :add] 
-                                                     ["README.md" :add] 
-                                                     ["project.clj" :add] 
-                                                     ["src/clj_jgit/core.clj" :add] 
-                                                     ["src/clj_jgit/util/print.clj" :add] 
-                                                     ["test/clj_jgit/test/core.clj" :add]], 
-                                                    :author "Daniel Gregoire", 
-                                                    :email "daniel.l.gregoire@gmail.com", 
-                                                    :message "Initial commit", 
-                                                    :branches ["refs/heads/master"], 
-                                                    :merge false, 
+      (are
+         [commit-ish info] (let [raw-data (-> commit-ish
+                                              ((partial find-rev-commit repo (new-rev-walk repo)))
+                                              ((partial commit-info repo)))
+                                 expected-basic (dissoc raw-data :repo :raw :time :branches)
+                                 info-basic (dissoc info :branches)
+                                 target-branch (-> info :branches (first))]
+                             (and (= expected-basic info-basic)
+                                  (some #(= % target-branch) (:branches raw-data))))
+        "38dd57264cf5c05fb77211c8347d1f16e4474623" {:changed_files
+                                                    [[".gitignore" :add]
+                                                     ["README.md" :add]
+                                                     ["project.clj" :add]
+                                                     ["src/clj_jgit/core.clj" :add]
+                                                     ["src/clj_jgit/util/print.clj" :add]
+                                                     ["test/clj_jgit/test/core.clj" :add]],
+                                                    :author "Daniel Gregoire",
+                                                    :email "daniel.l.gregoire@gmail.com",
+                                                    :message "Initial commit",
+                                                    :branches ["refs/heads/master"],
+                                                    :merge false,
                                                     :id "38dd57264cf5c05fb77211c8347d1f16e4474623"}
-        "edb462cd4ea2f351c4c5f20ec0952e70e113c489" {:changed_files 
-                                                    [["src/clj_jgit/porcelain.clj" :edit] 
-                                                     ["src/clj_jgit/util.clj" :add] 
-                                                     ["src/clj_jgit/util/core.clj" :delete] 
-                                                     ["src/clj_jgit/util/print.clj" :delete] 
-                                                     ["test/clj_jgit/test/core.clj" :edit]], 
-                                                    :author "vijaykiran", 
-                                                    :email "mail@vijaykiran.com", 
-                                                    :message "Utils - move into a single file.\n- Test for utils method.", 
-                                                    :branches ["refs/heads/master"], 
-                                                    :merge false, 
+        "edb462cd4ea2f351c4c5f20ec0952e70e113c489" {:changed_files
+                                                    [["src/clj_jgit/porcelain.clj" :edit]
+                                                     ["src/clj_jgit/util.clj" :add]
+                                                     ["src/clj_jgit/util/core.clj" :delete]
+                                                     ["src/clj_jgit/util/print.clj" :delete]
+                                                     ["test/clj_jgit/test/core.clj" :edit]],
+                                                    :author "vijaykiran",
+                                                    :email "mail@vijaykiran.com",
+                                                    :message "Utils - move into a single file.\n- Test for utils method.",
+                                                    :branches ["refs/heads/master"],
+                                                    :merge false,
                                                     :id "edb462cd4ea2f351c4c5f20ec0952e70e113c489"}
-        "0d3d1c2e7b6c47f901fcae9ef661a22948c64573" {:changed_files 
-                                                    [[".gitignore" :edit] 
-                                                     ["src/clj_jgit/porcelain.clj" :edit] 
-                                                     ["src/clj_jgit/util.clj" :add] 
-                                                     ["src/clj_jgit/util/core.clj" :delete] 
-                                                     ["src/clj_jgit/util/print.clj" :delete] 
-                                                     ["test/clj_jgit/test/core.clj" :edit] 
-                                                     ["test/clj_jgit/test/porcelain.clj" :add]], 
-                                                    :author "Daniel Gregoire", 
-                                                    :email "daniel.l.gregoire@gmail.com", 
-                                                    :message "Merge pull request #2 from vijaykiran/master\n\nInit Tests", 
-                                                    :branches ["refs/heads/master"], 
-                                                    :merge true, 
+        "0d3d1c2e7b6c47f901fcae9ef661a22948c64573" {:changed_files
+                                                    [[".gitignore" :edit]
+                                                     ["src/clj_jgit/porcelain.clj" :edit]
+                                                     ["src/clj_jgit/util.clj" :add]
+                                                     ["src/clj_jgit/util/core.clj" :delete]
+                                                     ["src/clj_jgit/util/print.clj" :delete]
+                                                     ["test/clj_jgit/test/core.clj" :edit]
+                                                     ["test/clj_jgit/test/porcelain.clj" :add]],
+                                                    :author "Daniel Gregoire",
+                                                    :email "daniel.l.gregoire@gmail.com",
+                                                    :message "Merge pull request #2 from vijaykiran/master\n\nInit Tests",
+                                                    :branches ["refs/heads/master"],
+                                                    :merge true,
                                                     :id "0d3d1c2e7b6c47f901fcae9ef661a22948c64573"})))
 
   (testing "changes-for should return nil on invalid commits"

--- a/test/clj_jgit/test/querying.clj
+++ b/test/clj_jgit/test/querying.clj
@@ -24,7 +24,7 @@
   (testing "branches-for"
     (read-only-repo
       (let [first-commit (resolve-object "38dd57264cf5c05fb77211c8347d1f16e4474623" repo)]
-        (is (= ["refs/heads/master"] (branches-for repo first-commit))))))
+        (is (some #(= % "refs/heads/master") (branches-for repo first-commit))))))
 
   (testing "changed-files" 
     (read-only-repo


### PR DESCRIPTION
This pull request refactors with-identity to allow runtime-destructuring instead of compile-time
destructuring.

Also it fixes some tests to allow the presence of local branches without breaking the tests.