### PR TITLE
Easy redefine SSH key using with-identity macro

### DIFF
--- a/src/clj_jgit/porcelain.clj
+++ b/src/clj_jgit/porcelain.clj
@@ -476,9 +476,13 @@
                         (.getBytes *ssh-prvkey* )
                         (.getBytes *ssh-pubkey*)
                         (.getBytes *ssh-passphrase*)))
+        (when (and *ssh-identity-name* (not (and *ssh-prvkey* *ssh-pubkey*)))
+          (if (empty? *ssh-passphrase*)
+            (.addIdentity jsch *ssh-identity-name*)
+            (.addIdentity jsch *ssh-identity-name* (.getBytes *ssh-passphrase*))))
         (doseq [{:keys [name private-key public-key passphrase]
                  :or {passphrase ""}} *ssh-identities*]
-          (.addIdentity jsch 
+          (.addIdentity jsch
                         (or name (str "key-" (.hashCode private-key)))
                         (.getBytes private-key)
                         (.getBytes public-key)


### PR DESCRIPTION
It's often the case one needs to redefine RSA key to use to push local changes to a remote repository. Unfortunately the current implementation of `with-identity` macro forces user to pass private and public keys as strings in order to redefine the identity. This patch make it possible to redefine identity in the following way:

``` clojure
(with-identity {:name "/path/to/the/private/key" :exclusive true}
  (-> repo (.push) (.call))
```

Or using passphrase

``` clojure
(with-identity {:name "/path/to/the/private/key" :passphrase "$ecReT" :exclusive true}
  (-> repo (.push) (.call))
```
