### PR TITLE
Upgrade dependencies and squash (most) reflection warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,8 @@ lein: 2.8.1
 git:
   depth: 9999999
 
-addons:
-  apt:
-    packages:
-      - openjdk-6-jdk
-
+# Note: the latest versions of JGit only support JVM 1.8+
 jdk:
-  - openjdk6
-  - openjdk7
   - openjdk8
   - oraclejdk8
   - oraclejdk9

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: clojure
+dist: trusty
 sudo: false
 lein: 2.8.1
 
@@ -8,11 +9,10 @@ addons:
       - openjdk-6-jdk
 
 jdk:
-  - oraclejdk9
+  - openjdk6
+  - openjdk7
   - openjdk8
   - oraclejdk8
-  - openjdk7
-  - oraclejdk7
-  - openjdk6
+  - oraclejdk9
 
 script: lein with-profile dev do check, test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ dist: trusty
 sudo: false
 lein: 2.8.1
 
+git:
+  depth: 9999999
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,17 @@
+sudo: false
+dist: trusty
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
 language: clojure
-lein: lein2
+lein: 2.8.1
 jdk:
+  - oraclejdk9
+  - openjdk8
+  - oraclejdk8
   - openjdk7
   - oraclejdk7
   - openjdk6
-script: "lein2 with-profile dev test"
+
+script: lein with-profile dev do check, test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
+language: clojure
 sudo: false
-dist: trusty
+lein: 2.8.1
+
 addons:
   apt:
     packages:
       - openjdk-6-jdk
-language: clojure
-lein: 2.8.1
+
 jdk:
   - oraclejdk9
   - openjdk8

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject clj-jgit "0.9.1-SNAPSHOT"
   :description "Clojure wrapper for JGit"
-  :dependencies [[org.eclipse.jgit/org.eclipse.jgit "4.8.0.201706111038-r" :exclusions [com.jcraft/jsch]]
+  :dependencies [[org.eclipse.jgit/org.eclipse.jgit "4.11.0.201803080745-r" :exclusions [com.jcraft/jsch]]
                  [com.jcraft/jsch "0.1.54"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]]}}
-  :plugins [[lein-marginalia "0.9.0"]]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.9.0"]]}}
+  :plugins [[lein-marginalia "0.9.1"]]
   :repositories {"jgit-repository" "https://repo.eclipse.org/content/groups/releases/"})

--- a/src/clj_jgit/internal.clj
+++ b/src/clj_jgit/internal.clj
@@ -17,9 +17,9 @@
 
 (defn close-rev-walk
   "If given `rev-walk` is a JGit RevWalk instance release any of it's used resources, returns nil either way"
-  [^org.eclipse.jgit.revwalk.RevWalk rev-walk]
+  [rev-walk]
   (when (instance? org.eclipse.jgit.revwalk.RevWalk rev-walk)
-    (.close rev-walk)))
+    (.close ^org.eclipse.jgit.revwalk.RevWalk rev-walk)))
 
 (defn new-tree-walk
   "Create new recursive TreeWalk instance (mutable)"

--- a/src/clj_jgit/internal.clj
+++ b/src/clj_jgit/internal.clj
@@ -17,7 +17,7 @@
 
 (defn close-rev-walk
   "If given `rev-walk` is a JGit RevWalk instance release any of it's used resources, returns nil either way"
-  [rev-walk]
+  [^org.eclipse.jgit.revwalk.RevWalk rev-walk]
   (when (instance? org.eclipse.jgit.revwalk.RevWalk rev-walk)
     (.close rev-walk)))
 
@@ -36,7 +36,7 @@
 
 (defprotocol Resolvable
   "Protocol for things that resolve ObjectId's."
-  (resolve-object [commit-ish repo]
+  (^org.eclipse.jgit.lib.ObjectId resolve-object [commit-ish repo]
     "Find ObjectId instance for any Git name: commit-ish, tree-ish or blob. Accepts ObjectId instances and just passes them through."))
 
 (extend-type String

--- a/src/clj_jgit/util.clj
+++ b/src/clj_jgit/util.clj
@@ -24,7 +24,7 @@
      ~@body))
 
 (defmethod print-method org.eclipse.jgit.internal.storage.file.RefDirectory$LooseRef
-  [o w]
+  [^org.eclipse.jgit.internal.storage.file.RefDirectory$LooseRef o w]
   (print-simple
    (str "#<" (.replaceFirst (str (.getClass o)) "class " "") ", "
         "Name: " (.getName o) ", "


### PR DESCRIPTION
Apologies for the fly-by PR, but I use `lein check` a lot and so when a library I'm using has a bunch of reflection warnings it makes it harder to improve my own code.

Tests pass for me here:
```
$ lein do check, test
Compiling namespace clj-jgit.util
Compiling namespace clj-jgit.porcelain
Reflection warning, clj_jgit/porcelain.clj:549:18 - call to method getJSch can't be resolved (target class is unknown).
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Compiling namespace clj-jgit.querying
Compiling namespace clj-jgit.internal
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.

lein test clj-jgit.test.core

lein test clj-jgit.test.helpers

lein test clj-jgit.test.internal

lein test clj-jgit.test.porcelain

lein test clj-jgit.test.querying

lein test clj-jgit.test.util

Ran 12 tests containing 69 assertions.
0 failures, 0 errors.
```

Note that I'm new to JGit, so please carefully review all of the type hints I added to make sure they're correct!
