### PR TITLE
clj-jgit.porcelain/git-fetch: Removes cast of string array to java.util.List

### DIFF
--- a/src/clj_jgit/porcelain.clj
+++ b/src/clj_jgit/porcelain.clj
@@ -677,7 +677,7 @@
         (if (some? recurse-subs)
           (.setRecurseSubmodules cmd (recurse-subs fetch-recurse-submodules-modes)) cmd)
         (if (some? ref-specs)
-          (.setRefSpecs cmd (into-array String (seq?! ref-specs))) cmd)
+          (.setRefSpecs cmd ^"[Ljava.lang.String;" (into-array String (seq?! ref-specs))) cmd)
         (if (some? remote)
           (.setRemote cmd remote) cmd)
         (if (some? rm-deleted-refs?)

--- a/src/clj_jgit/porcelain.clj
+++ b/src/clj_jgit/porcelain.clj
@@ -677,7 +677,7 @@
         (if (some? recurse-subs)
           (.setRecurseSubmodules cmd (recurse-subs fetch-recurse-submodules-modes)) cmd)
         (if (some? ref-specs)
-          (.setRefSpecs cmd ^List (into-array String (seq?! ref-specs))) cmd)
+          (.setRefSpecs cmd (into-array String (seq?! ref-specs))) cmd)
         (if (some? remote)
           (.setRemote cmd remote) cmd)
         (if (some? rm-deleted-refs?)

--- a/test/clj_jgit/test/porcelain.clj
+++ b/test/clj_jgit/test/porcelain.clj
@@ -91,6 +91,8 @@
       (git-commit repo-a commit-msg)
       (git-remote-add repo-a "origin" (.getAbsolutePath bare-dir))
       (is (instance? PushResult (-> repo-a git-push first))))
+    (testing "git-fetch works for repo-a"
+      (git-fetch-all repo-a))
     (testing "git-pull works for repo-b using repo-bare as remote and repo-b has a commit with matching message"
       (git-remote-add repo-b "origin" (.getAbsolutePath bare-dir))
       (is (instance? PullResult (git-pull repo-b)))


### PR DESCRIPTION
## Summary

This fixes a bug in `clj-jgit.porcelain/git-fetch` when providing `:ref-specs`.