### PR TITLE
README: Correct `with-credentials` :user => :login

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ protected. For further configuration any command may be wrapped with the `with-c
   (git-push my-repo :tags true))
 
 ;; Use user/pw auth instead of key based auth
-(with-credentials {:user "someuser" :pw "$ecReT"}
+(with-credentials {:login "someuser" :pw "$ecReT"}
   (git-pull my-repo))
 ```
 


### PR DESCRIPTION
As per the code https://github.com/clj-jgit/clj-jgit/blob/fb6e8a3b472652b9682a2dfea3b0d82ebfa002aa/src/clj_jgit/porcelain.clj#L158

Locally it works with `:login`, not with `:user`