### PR TITLE
Feature: obtain repository from filepath within git repository

### DIFF
--- a/src/clj_jgit/porcelain.clj
+++ b/src/clj_jgit/porcelain.clj
@@ -226,13 +226,13 @@
                     (.addCeilingDirectories ceiling-dirs)
                     (.readEnvironment)
                     (.findGitDir path))]
-    (if (nil? (.getGitDir builder))
-      (throw
-       (FileNotFoundException. (str "Could not load a git repository at '" path "'"
-                                    "with ceiling dirs: " ceiling-dirs)))
+    (if (.getGitDir builder)
       (-> builder
           (.build)
-          (Git.)))))
+          (Git.))
+      (throw
+       (FileNotFoundException. (str "Could not load a git repository at '" path "'"
+                                    "with ceiling dirs: " ceiling-dirs))))))
 
 
 (defmacro with-repo

--- a/src/clj_jgit/porcelain.clj
+++ b/src/clj_jgit/porcelain.clj
@@ -222,12 +222,17 @@
 (defn find-repo
   "Given a `path` located somewhere within a Git repository, load the repository"
   ^Git [path & {:keys [ceiling-dirs]}]
-  (-> (RepositoryBuilder.)
-      (.addCeilingDirectories ceiling-dirs)
-      (.readEnvironment)
-      (.findGitDir path)
-      (.build)
-      (Git.)))
+  (let [builder (-> (RepositoryBuilder.)
+                    (.addCeilingDirectories ceiling-dirs)
+                    (.readEnvironment)
+                    (.findGitDir path))]
+    (if (nil? (.getGitDir builder))
+      (throw
+       (FileNotFoundException. (str "Could not load a git repository at '" path "'")))
+      (-> builder
+          (.build)
+          (Git.)))))
+
 
 (defmacro with-repo
   "Load Git repository at `path` and bind it to `repo`, then evaluate `body`.

--- a/src/clj_jgit/porcelain.clj
+++ b/src/clj_jgit/porcelain.clj
@@ -219,6 +219,16 @@
     (throw
       (FileNotFoundException. (str "The Git repository at '" path "' could not be located.")))))
 
+(defn find-repo
+  "Given a `path` located somewhere within a Git repository, load the repository"
+  ^Git [path & {:keys [ceiling-dirs]}]
+  (-> (RepositoryBuilder.)
+      (.addCeilingDirectories ceiling-dirs)
+      (.readEnvironment)
+      (.findGitDir path)
+      (.build)
+      (Git.)))
+
 (defmacro with-repo
   "Load Git repository at `path` and bind it to `repo`, then evaluate `body`.
   Also provides a fresh `rev-walk` instance for `repo`."

--- a/src/clj_jgit/porcelain.clj
+++ b/src/clj_jgit/porcelain.clj
@@ -234,7 +234,6 @@
        (FileNotFoundException. (str "Could not load a git repository at '" path "'"
                                     " with ceiling dirs: " ceiling-dirs))))))
 
-
 (defmacro with-repo
   "Load Git repository at `path` and bind it to `repo`, then evaluate `body`.
   Also provides a fresh `rev-walk` instance for `repo`."

--- a/src/clj_jgit/porcelain.clj
+++ b/src/clj_jgit/porcelain.clj
@@ -228,7 +228,8 @@
                     (.findGitDir path))]
     (if (nil? (.getGitDir builder))
       (throw
-       (FileNotFoundException. (str "Could not load a git repository at '" path "'")))
+       (FileNotFoundException. (str "Could not load a git repository at '" path "'"
+                                    "with ceiling dirs: " ceiling-dirs)))
       (-> builder
           (.build)
           (Git.)))))

--- a/src/clj_jgit/porcelain.clj
+++ b/src/clj_jgit/porcelain.clj
@@ -232,7 +232,7 @@
           (Git.))
       (throw
        (FileNotFoundException. (str "Could not load a git repository at '" path "'"
-                                    "with ceiling dirs: " ceiling-dirs))))))
+                                    " with ceiling dirs: " ceiling-dirs))))))
 
 
 (defmacro with-repo


### PR DESCRIPTION
Adds functionality to obtain a `Repository` object given a file anywhere within a Git repository. Includes support for `addCeilingDirectories` and would be used like so (as an example):

**Usage without ceiling directories**

```clj
(find-repo (io/file "/Users/ml/code/clj-jgit/src/clj_jgit/porcelain.clj"))
;; => #object[org.eclipse.jgit.api.Git 0x1ff2d3f "Git[Repository[/Users/ml/code/clj-jgit/.git]]"]
```

**Usage with ceiling directories**

```clj
(def ceil [(io/file "/Users/ml/code/clj-jgit/src")])
(find-repo (io/file "/Users/ml/code/clj-jgit/src/clj_jgit/porcelain.clj") :ceiling-dirs ceil)
Execution error (FileNotFoundException) at clj-jgit.porcelain/find-repo (form-init17805399835728471910.clj:234).
Could not load a git repository at '/Users/ml/code/clj-jgit/src/clj_jgit/porcelain.clj' with ceiling dirs: [#object[java.io.File 0xe82bcfe "/Users/ml/code/clj-jgit/src"]]
```