### PR TITLE
Update JGit version

### DIFF
--- a/.github/workflows/tests-on-push.yml
+++ b/.github/workflows/tests-on-push.yml
@@ -23,13 +23,13 @@ jobs:
       - name: Install java
         uses: actions/setup-java@v3
         with:
-          distribution: "temurin"
-          java-version: "17"
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Install clojure tools
         uses: DeLaGuardo/setup-clojure@10.1
         with:
-          cli: "latest"
+          cli: 'latest'
           lein: 2.9.1
           clj-kondo: 2023.05.26
 
@@ -54,4 +54,4 @@ jobs:
         run: lein with-profile dev do check, test
 
       - name: Lint
-        run: clj-kondo --fail-level error --parallel  --lint src --config '{:output {:pattern "::{{level}} file={{filename}},line={{row}},col={{col}}::{{message}}"}}'
+        run: clj-kondo --parallel  --lint src --config '{:output {:pattern "::{{level}} file={{filename}},line={{row}},col={{col}}::{{message}}"}}'

--- a/.github/workflows/tests-on-push.yml
+++ b/.github/workflows/tests-on-push.yml
@@ -7,9 +7,7 @@ on:
   pull_request:
 
 jobs:
-
   clojure:
-
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
@@ -25,19 +23,15 @@ jobs:
       - name: Install java
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
 
       - name: Install clojure tools
         uses: DeLaGuardo/setup-clojure@10.1
         with:
-          cli: 'latest'
+          cli: "latest"
           lein: 2.9.1
-
-      - name: Install clj-kondo
-        uses: DeLaGuardo/setup-clj-kondo@afc83dbbf4e7e32e04649e29dbf30668d30e9e3e
-        with:
-          version: '2023.05.26'
+          clj-kondo: 2023.05.26
 
       - name: Cache clojure deps
         uses: actions/cache@v3
@@ -60,4 +54,4 @@ jobs:
         run: lein with-profile dev do check, test
 
       - name: Lint
-        run: clj-kondo --lint src --config '{:output {:pattern "::{{level}} file={{filename}},line={{row}},col={{col}}::{{message}}"}}'
+        run: clj-kondo --fail-level error --parallel  --lint src --config '{:output {:pattern "::{{level}} file={{filename}},line={{row}},col={{col}}::{{message}}"}}'

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "test"]
 
  :deps
- {org.eclipse.jgit/org.eclipse.jgit            {:mvn/version "6.4.0.202211300538-r"}
-  org.eclipse.jgit/org.eclipse.jgit.ssh.apache {:mvn/version "6.4.0.202211300538-r"}
-  org.eclipse.jgit/org.eclipse.jgit.gpg.bc     {:mvn/version "6.4.0.202211300538-r"}}}
+ {org.eclipse.jgit/org.eclipse.jgit            {:mvn/version "6.5.0.202303070854-r"}
+  org.eclipse.jgit/org.eclipse.jgit.ssh.apache {:mvn/version "6.5.0.202303070854-r"}
+  org.eclipse.jgit/org.eclipse.jgit.gpg.bc     {:mvn/version "6.5.0.202303070854-r"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "test"]
 
  :deps
- {org.eclipse.jgit/org.eclipse.jgit            {:mvn/version "6.5.0.202303070854-r"}
-  org.eclipse.jgit/org.eclipse.jgit.ssh.apache {:mvn/version "6.5.0.202303070854-r"}
-  org.eclipse.jgit/org.eclipse.jgit.gpg.bc     {:mvn/version "6.5.0.202303070854-r"}}}
+ {org.eclipse.jgit/org.eclipse.jgit            {:mvn/version "6.6.0.202305301015-r"}
+  org.eclipse.jgit/org.eclipse.jgit.ssh.apache {:mvn/version "6.6.0.202305301015-r"}
+  org.eclipse.jgit/org.eclipse.jgit.gpg.bc     {:mvn/version "6.6.0.202305301015-r"}}}

--- a/docs/uberdoc.html
+++ b/docs/uberdoc.html
@@ -3606,6 +3606,7 @@ Create a new tracking branch for a remote branch and make it the current branch:
 :dir            The optional directory associated with the clone operation. If
                 the directory isn't set, a name associated with the source uri
                 will be used. (default: nil)
+:depth          Create a shallow clone with a history truncated to the specified number of commits. (default: nil)
 :git-dir        The repository meta directory (.git). (default: nil = automatic)
 :no-checkout?   If set to true no branch will be checked out after the clone.
                 This enhances performance of the clone command when there is no
@@ -3617,7 +3618,7 @@ Create a new tracking branch for a remote branch and make it the current branch:
                 (default: nil)
 </code></pre>
 </td><td class="codes"><pre class="brush: clojure">(defn git-clone
-  [uri &amp; {:keys [bare? branch callback clone-all? clone-branches clone-subs? dir git-dir no-checkout? monitor remote]
+  [uri &amp; {:keys [bare? branch callback clone-all? clone-branches clone-subs? dir depth git-dir no-checkout? monitor remote]
           :or   {bare?          false
                  branch         &quot;master&quot;
                  clone-all?     true
@@ -3625,6 +3626,7 @@ Create a new tracking branch for a remote branch and make it the current branch:
                  clone-subs?    false
                  callback       nil
                  dir            nil
+                 depth          nil
                  git-dir        nil
                  no-checkout?   false
                  monitor        nil
@@ -3640,6 +3642,8 @@ Create a new tracking branch for a remote branch and make it the current branch:
           (.setCallback cmd callback) cmd)
         (if (some? dir)
           (.setDirectory cmd (io/as-file dir)) cmd)
+        (if (some? depth)
+          (.setDepth cmd depth) cmd)
         (if (some? git-dir)
           (.setGitDir cmd (io/as-file git-dir)) cmd)
         (.setNoCheckout cmd no-checkout?)

--- a/docs/uberdoc.html
+++ b/docs/uberdoc.html
@@ -3971,7 +3971,7 @@ Create a new tracking branch for a remote branch and make it the current branch:
 </td><td class="codes"><pre class="brush: clojure">(defonce branch-rebase-modes
          {:interactive BranchConfig$BranchRebaseMode/INTERACTIVE
           :none        BranchConfig$BranchRebaseMode/NONE
-          :preserve    BranchConfig$BranchRebaseMode/PRESERVE
+          :merges    BranchConfig$BranchRebaseMode/MERGES
           :rebase      BranchConfig$BranchRebaseMode/REBASE})</pre></td></tr><tr><td class="docs"><p>Fetch from and integrate with another repository or a local branch.</p>
 
 <pre><code>Options:
@@ -3989,8 +3989,7 @@ Create a new tracking branch for a remote branch and make it the current branch:
 :rebase-mode      Keyword that sets the rebase mode to use after fetching:
                     :rebase       Equivalent to --rebase: use rebase instead of merge
                                   after fetching.
-                    :preserve     Equivalent to --preserve-merges: rebase preserving
-                                  local merge commits.
+                    :merges       Equivalent to --rebase-merges: the local merge commits are included in the rebase.
                     :interactive  Equivalent to --interactive: use interactive rebase.
                     :none         Equivalent to --no-rebase: merge instead of rebasing.
                   When nil use the setting defined in the git configuration, either

--- a/src/clj_jgit/porcelain.clj
+++ b/src/clj_jgit/porcelain.clj
@@ -497,6 +497,7 @@
     :dir            The optional directory associated with the clone operation. If
                     the directory isn't set, a name associated with the source uri
                     will be used. (default: nil)
+    :depth          Create a shallow clone with a history truncated to the specified number of commits. (default: nil)
     :git-dir        The repository meta directory (.git). (default: nil = automatic)
     :no-checkout?   If set to true no branch will be checked out after the clone.
                     This enhances performance of the clone command when there is no
@@ -520,7 +521,7 @@
                       :no-tags      - Never fetch tags, even if we have the thing it points at.
                     (default: :auto-follow)
   "
-  [uri & {:keys [bare? branch callback clone-all? clone-branches clone-subs? dir git-dir no-checkout? mirror? monitor
+  [uri & {:keys [bare? branch callback clone-all? clone-branches clone-subs? dir depth git-dir no-checkout? mirror? monitor
                  remote tags]
           :or   {bare?          false
                  branch         "master"
@@ -529,6 +530,7 @@
                  clone-subs?    false
                  callback       nil
                  dir            nil
+                 depth          nil
                  git-dir        nil
                  no-checkout?   false
                  mirror?        false
@@ -546,6 +548,8 @@
           (.setCallback cmd callback) cmd)
         (if (some? dir)
           (.setDirectory cmd (io/as-file dir)) cmd)
+        (if (some? depth)
+          (.setDepth cmd depth) cmd)
         (if (some? git-dir)
           (.setGitDir cmd (io/as-file git-dir)) cmd)
         (.setNoCheckout cmd no-checkout?)

--- a/src/clj_jgit/porcelain.clj
+++ b/src/clj_jgit/porcelain.clj
@@ -990,7 +990,7 @@
 (defonce branch-rebase-modes
          {:interactive BranchConfig$BranchRebaseMode/INTERACTIVE
           :none        BranchConfig$BranchRebaseMode/NONE
-          :preserve    BranchConfig$BranchRebaseMode/PRESERVE
+          :merges      BranchConfig$BranchRebaseMode/MERGES
           :rebase      BranchConfig$BranchRebaseMode/REBASE})
 
 (defn git-pull
@@ -1011,8 +1011,7 @@
     :rebase-mode      Keyword that sets the rebase mode to use after fetching:
                         :rebase       Equivalent to --rebase: use rebase instead of merge
                                       after fetching.
-                        :preserve     Equivalent to --preserve-merges: rebase preserving
-                                      local merge commits.
+                        :merges       Equivalent to --rebase-merges: the local merge commits are included in the rebase.
                         :interactive  Equivalent to --interactive: use interactive rebase.
                         :none         Equivalent to --no-rebase: merge instead of rebasing.
                       When nil use the setting defined in the git configuration, either


### PR DESCRIPTION
In new 6.5 version PRESERVE option has been replaced by MERGES. Please check release notes:
https://projects.eclipse.org/projects/technology.jgit/releases/6.5.0

Also support new setDepth option in git-clone  got shallow clone

Related issue:
- https://github.com/clj-jgit/clj-jgit/issues/80

@edannenberg check please when you will have time. Cheers