### PR TITLE
Update JGit to version 6.6.1 to mitigate CVE-2023-4759

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "test"]
 
  :deps
- {org.eclipse.jgit/org.eclipse.jgit            {:mvn/version "6.6.0.202305301015-r"}
-  org.eclipse.jgit/org.eclipse.jgit.ssh.apache {:mvn/version "6.6.0.202305301015-r"}
-  org.eclipse.jgit/org.eclipse.jgit.gpg.bc     {:mvn/version "6.6.0.202305301015-r"}}}
+ {org.eclipse.jgit/org.eclipse.jgit            {:mvn/version "6.6.1.202309021850-r"}
+  org.eclipse.jgit/org.eclipse.jgit.ssh.apache {:mvn/version "6.6.1.202309021850-r"}
+  org.eclipse.jgit/org.eclipse.jgit.gpg.bc     {:mvn/version "6.6.1.202309021850-r"}}}

--- a/src/clj_jgit/porcelain.clj
+++ b/src/clj_jgit/porcelain.clj
@@ -1006,7 +1006,11 @@
          {:interactive BranchConfig$BranchRebaseMode/INTERACTIVE
           :none        BranchConfig$BranchRebaseMode/NONE
           :merges      BranchConfig$BranchRebaseMode/MERGES
-          :rebase      BranchConfig$BranchRebaseMode/REBASE})
+          :rebase      BranchConfig$BranchRebaseMode/REBASE
+          ;; Maintain backwards compatibility with the renamed PRESERVE rebase mode
+          ;; https://github.com/eclipse-jgit/jgit/commit/0518a6b0c16c1bce210bc9b2626104ef05975ee1
+          ;; https://github.com/eclipse-jgit/jgit/commit/032eef5b12a25e0da48004eea589966ae0652433
+          :preserve    BranchConfig$BranchRebaseMode/MERGES})
 
 (defn git-pull
   "Fetch from and integrate with another repository or a local branch.


### PR DESCRIPTION
Also preserve backwards compatibility with the legacy `:preserve` BranchRebaseMode.