### PR TITLE
git-commit with custom author date

### DIFF
--- a/docs/uberdoc.html
+++ b/docs/uberdoc.html
@@ -2866,146 +2866,83 @@ net.brehaut.ClojureTools = (function (SH) {
   };
 })(SyntaxHighlighter);
 </script><title>clj-jgit -- Marginalia</title></head><body><table><tr><td class="docs"><div class="header"><h1 class="project-name">clj-jgit</h1><h2 class="project-version">1.1.0</h2><br /><p>Clojure wrapper for JGit</p>
-</div></td><td class="codes" style="text-align: center; vertical-align: middle;color: #666;padding-right:20px"><br /><br /><br />(this space intentionally left almost blank)</td></tr><tr><td class="docs"><div class="toc"><a name="toc"><h3>namespaces</h3></a><ul><li><a href="#clj-jgit.diff">clj-jgit.diff</a></li><li><a href="#clj-jgit.querying">clj-jgit.querying</a></li><li><a href="#clj-jgit.util">clj-jgit.util</a></li><li><a href="#clj-jgit.internal">clj-jgit.internal</a></li><li><a href="#clj-jgit.porcelain">clj-jgit.porcelain</a></li></ul></div></td><td class="codes">&nbsp;</td></tr><tr><td class="docs"><div class="docs-header"><a class="anchor" href="#clj-jgit.diff" name="clj-jgit.diff"><h1 class="project-name">clj-jgit.diff</h1><a class="toc-link" href="#toc">toc</a></a></div></td><td class="codes" /></tr><tr><td class="docs">
-</td><td class="codes"><pre class="brush: clojure">(ns clj-jgit.diff
-  (:import (java.io ByteArrayOutputStream OutputStream)
-           (java.util List)
-           (org.eclipse.jgit.diff DiffFormatter EditList HistogramDiff RawText RawTextComparator)
-           (org.eclipse.jgit.treewalk.filter TreeFilter)))</pre></td></tr><tr><td class="docs">
-</td><td class="codes"><pre class="brush: clojure">(defonce raw-text-comparator-modes {:default            RawTextComparator/DEFAULT            ; No special treatment
-                                    :ws-ignore-all      RawTextComparator/WS_IGNORE_ALL      ; Ignores all whitespace
-                                    :ws-ignore-leading  RawTextComparator/WS_IGNORE_LEADING  ; Ignore leading whitespace
-                                    :ws-ignore-trailing RawTextComparator/WS_IGNORE_TRAILING ; Ignores trailing whitespace
-                                    :ws-ignore-change   RawTextComparator/WS_IGNORE_CHANGE}) ; Ignores whitespace occurring between non-whitespace characters</pre></td></tr><tr><td class="docs"><p>Returns a new <code>org.eclipse.jgit.diff.RawText</code> instance for given string <code>s</code></p>
-</td><td class="codes"><pre class="brush: clojure">(defn get-raw-text
-  ^RawText [^String s]
-  (-&gt; s .getBytes RawText.))</pre></td></tr><tr><td class="docs"><p>Compare given <code>RawText</code> instances <code>a</code> and <code>b</code>, returns a new <code>org.eclipse.jgit.diff.EditList</code> instance</p>
-</td><td class="codes"><pre class="brush: clojure">(defn diff-raw-text
-  ^EditList [a b &amp; {:keys [comparator-mode] :or {comparator-mode :default}}]
-  (let [comparator (comparator-mode raw-text-comparator-modes)]
-    (-&gt; (HistogramDiff.)
-        (.diff comparator a b))))</pre></td></tr><tr><td class="docs"><p>Compare given strings <code>a</code> and <code>b</code>, returns a new <code>org.eclipse.jgit.diff.EditList</code> instance</p>
-</td><td class="codes"><pre class="brush: clojure">(defn diff-string
-  ^EditList [a b &amp; {:keys [comparator-mode] :or {comparator-mode :default}}]
-  (diff-raw-text (get-raw-text a) (get-raw-text b) :comparator-mode comparator-mode))</pre></td></tr><tr><td class="docs"><p>Returns a new <code>org.eclipse.jgit.diff.DiffFormatter</code> instance. Note that depending on the used <code>format</code> method some
-  options are ignored, i.e. setting a <code>prefix</code> or <code>path-filter</code> has no effect when formatting raw-text-diffs.</p>
+</div></td><td class="codes" style="text-align: center; vertical-align: middle;color: #666;padding-right:20px"><br /><br /><br />(this space intentionally left almost blank)</td></tr><tr><td class="docs"><div class="toc"><a name="toc"><h3>namespaces</h3></a><ul><li><a href="#clj-jgit.util">clj-jgit.util</a></li><li><a href="#clj-jgit.querying">clj-jgit.querying</a></li><li><a href="#clj-jgit.internal">clj-jgit.internal</a></li><li><a href="#clj-jgit.porcelain">clj-jgit.porcelain</a></li><li><a href="#clj-jgit.diff">clj-jgit.diff</a></li></ul></div></td><td class="codes">&nbsp;</td></tr><tr><td class="docs"><div class="docs-header"><a class="anchor" href="#clj-jgit.util" name="clj-jgit.util"><h1 class="project-name">clj-jgit.util</h1><a class="toc-link" href="#toc">toc</a></a></div></td><td class="codes" /></tr><tr><td class="docs">
+</td><td class="codes"><pre class="brush: clojure">(ns clj-jgit.util
+  (:require [clojure.java.io :as io])
+  (:import (java.io IOException)
+           (org.eclipse.jgit.internal.storage.file RefDirectory$LooseRef)
+           (org.eclipse.jgit.lib PersonIdent)))</pre></td></tr><tr><td class="docs"><p>Delete file <code>f</code>. If <code>f</code> is a directory, recursively deletes all files and directories within the directory. Raises an
+  exception if it fails, unless <code>silently</code> is true.</p>
+</td><td class="codes"><pre class="brush: clojure">(defn recursive-delete-file
+  [f &amp; [silently]]
+  (let [file (io/file f)]
+    (if (.exists file)
+      (do (doseq [child (reverse (file-seq file))]
+            (io/delete-file child silently))
+          true)
+      (or silently
+          (throw (IOException. (str &quot;Couldn't find &quot; f)))))))</pre></td></tr><tr><td class="docs"><p>If given <code>obj</code> isn't sequential? returns a vec with <code>obj</code> as single element, else just returns it's input.</p>
+</td><td class="codes"><pre class="brush: clojure">(defn seq?!
+  [obj]
+  (if (sequential? obj) obj (vector obj)))</pre></td></tr><tr><td class="docs"><p>Repeatedly executes function <code>f</code> for each entry in <code>param-seq</code>. The function is passed the <code>cmd-instance</code> as first
+  arg and a single <code>param-seq</code> entry as second arg. If <code>param-seq</code> isn't sequential? it's wrapped into a vector.
+  Returns given <code>cmd-instance</code>.</p>
+
+<p>  Example that executes <code>.addFilepattern</code> on a JGit AddCommand instance for each given file, nicely threaded:</p>
+
+<pre><code>  (-&gt; (.add repo)
+    (doseq-cmd-fn! #(.addFilepattern ^AddCommand %1 %2) ["file1.txt" "file2.txt"])
+    (.call))
+</code></pre>
+</td><td class="codes"><pre class="brush: clojure">(defn doseq-cmd-fn!
+  [cmd-instance f param-seq]
+    (doseq [p (seq?! param-seq)]
+      (f cmd-instance p))
+    cmd-instance)</pre></td></tr><tr><td class="docs"><p>Given a URI to a Git resource, derive the name (for use in cloning to a directory)</p>
+</td><td class="codes"><pre class="brush: clojure">(defn name-from-uri
+  [uri]
+  (second (re-find #&quot;/([^/]*)\.git$&quot; uri)))</pre></td></tr><tr><td class="docs"><p>Special <code>when</code> macro for checking if an attribute isn't available or is an empty string</p>
+</td><td class="codes"><pre class="brush: clojure">(defmacro when-present
+  [obj &amp; body]
+  `(when (not (or (nil? ~obj) (empty? ~obj)))
+     ~@body))</pre></td></tr><tr><td class="docs">
+</td><td class="codes"><pre class="brush: clojure">(defmethod print-method RefDirectory$LooseRef
+  [^RefDirectory$LooseRef o w]
+  (print-simple
+    (str &quot;#&lt;&quot; (.replaceFirst (str (.getClass o)) &quot;class &quot; &quot;&quot;) &quot;, &quot;
+         &quot;Name: &quot; (.getName o) &quot;, &quot;
+         &quot;ObjectId: &quot; (.getName (.getObjectId o)) &quot;&gt;&quot;) w))</pre></td></tr><tr><td class="docs"><p>Removes a leading slash from a path</p>
+</td><td class="codes"><pre class="brush: clojure">(defn normalize-path
+  [path]
+  (if (= path &quot;/&quot;)
+    &quot;/&quot;
+    (if (= (first path) \/)
+      (subs path 1)
+      path)))</pre></td></tr><tr><td class="docs"><p>Construct a JGit <code>PersonIdent</code> object from a map</p>
+</td><td class="codes"><pre class="brush: clojure">(defn map-&gt;person-ident
+  ^PersonIdent
+  [{:keys [name email date timezone]}]
+  ;; if one is specified but not the other, PersonIdent constructor will fail
+  (if (or (some? date) (some? timezone))
+    (PersonIdent. ^String name ^String email date timezone)
+    (PersonIdent. ^String name ^String email)))</pre></td></tr><tr><td class="docs"><p>Convert given JGit <code>PersonIdent</code> object into a map.</p>
 
 <pre><code>Options:
-:abbreviation-length    `integer` that sets the number of digits to show for commit-ids.
-                        (default: 7)
-:binary-file-threshold  `integer` that sets the maximum file size for text files, in bytes.
-                        Files larger than this size will be assumed to be binary, even if they aren't.
-                        (default: 52428800)
-:context-lines          `integer` that sets the number of lines of context shown before and after a modification.
-                        (default: 3)
-:detect-renames?        `boolean` that sets rename detection. Ignored if `repository` is not set. Once enabled the
-                        detector can be configured away from its defaults by obtaining the instance directly by
-                        invoking `getRenameDetector()` on the formatter instance. Ignored when `:repository` is nil.
-                        (default: false)
-:monitor                Set a progress monitor. See JGit ProgressMonitor interface.
-                        (default: nil)
-:output-stream          The `OutputStream` instance the formatted diff is written to.
-                        (default: (ByteArrayOutputStream.))
-:path-filter            An `org.eclipse.jgit.treewalk.filter.TreeFilter` instance that limits the result, i.e.:
-                        `(PathFilter/create "project.clj")`. See `org.eclipse.jgit.treewalk.filter` namespace
-                        for all available filters or implement your own.
-                        (default: PathFilter/ALL)
-:prefix-new             A purely cosmetic `string` used as path prefix for the new side in the output. Can be empty
-                        but not nil.
-                        (default: "b/")
-:prefix-old             A purely cosmetic `string` used as path prefix for the old side in the output. Can be empty
-                        but not nil.
-                        (default: "a/")
-:quote-paths?           `boolean` that sets whether path names should be quoted. By default, the setting of
-                        `git config core.quotePath` is used. Ignored when `:repository` is nil.
-:repository             `Repository` instance the formatter can load object contents from. Once a repository has
-                        been set, the formatter must be released to ensure the internal ObjectReader is able to
-                        release its resources.
-                        (default: nil)
+
+:java-time  Use java.time objects for :date and :timezone.
+              :date      java.time.Instant
+              :timezone  java.time.ZoneId
+            (default: nil)
+              :date      java.util.Date
+              :timezone  java.util.TimeZone
 </code></pre>
-</td><td class="codes"><pre class="brush: clojure">(defn get-diff-formatter
-  ^DiffFormatter [&amp; {:keys [abbreviation-length binary-file-threshold context-lines detect-renames? monitor
-                            output-stream path-filter quote-paths? repository]
-                     :or   {abbreviation-length   7
-                            binary-file-threshold 52428800
-                            context-lines         3
-                            detect-renames?       nil
-                            monitor               nil
-                            output-stream         (ByteArrayOutputStream.)
-                            path-filter           TreeFilter/ALL
-                            quote-paths?          nil
-                            repository            nil}}]
-  (let [formatter (doto (DiffFormatter. output-stream)
-                    (.setAbbreviationLength abbreviation-length)
-                    (.setBinaryFileThreshold binary-file-threshold)
-                    (.setContext context-lines)
-                    (.setProgressMonitor monitor)
-                    (.setPathFilter path-filter))]
-    (when repository
-      (.setRepository formatter repository)
-      (when (some? detect-renames?) (.setDetectRenames formatter detect-renames?))
-      (when (some? quote-paths?) (.setQuotePaths formatter quote-paths?)))
-    formatter))</pre></td></tr><tr><td class="docs"><p>Compare given strings <code>a</code> and <code>b</code> and write a patch-style formatted string to given <code>:output-stream</code>. Always returns
-  the <code>output-stream</code>.</p>
-
-<p>  Options:</p>
-
-<p>  :comparator-mode  Keyword that sets how whitespace changes are handled:
-                      <code>:ws-ignore-all</code>      Ignores all whitespace
-                      <code>:ws-ignore-leading</code>  Ignore leading whitespace
-                      <code>:ws-ignore-trailing</code> Ignores trailing whitespace
-                      <code>:ws-ignore-change</code>   Ignores whitespace occurring between non-whitespace characters
-                      <code>:default</code>            No special treatment
-  :context-lines    <code>integer</code> that sets the number of lines of context shown before and after a modification.
-                    (default: 3)
-  :output-stream    The <code>OutputStream</code> instance the formatted diff is written to. Note that the returned stream is not
-                    flushed or closed, when in doubt use <code>with-open</code>.
-                    (default: (ByteArrayOutputStream.))</p>
-</td><td class="codes"><pre class="brush: clojure">(defn diff-string-formatted
-  ^OutputStream [a b &amp; {:keys [comparator-mode context-lines output-stream]
-                        :or   {comparator-mode :default
-                               context-lines    3
-                               output-stream   (ByteArrayOutputStream.)}}]
-  (let [raw-a (get-raw-text a)
-        raw-b (get-raw-text b)
-        edit-list (diff-raw-text raw-a raw-b :comparator-mode comparator-mode)]
-    (-&gt; (get-diff-formatter :output-stream output-stream :context-lines context-lines)
-        (.format edit-list raw-a raw-b))
-    output-stream))</pre></td></tr><tr><td class="docs"><p>Set internal <code>state</code> field to given seq <code>s</code>Compare given sequences <code>a</code> and <code>b</code>, returns a new <code>org.eclipse.jgit.diff.EditList</code> instance</p>
-</td><td class="codes"><pre class="brush: clojure">#_{:clj-kondo/ignore [:unresolved-symbol]}
-(comment
-  ; JGit also supports diffing of sequences, subsequences and hashed sequences. Each type requires prior implementation of
-  ; its abstract classes, see https://download.eclipse.org/jgit/site/6.0.0.202111291000-r/apidocs/org/eclipse/jgit/diff/package-summary.html
-  ; Simple example for diffing Sequences below, sadly `proxy` and `reify` don't support adding new methods to abstract classes.
-  ; Note: requires aot compilation to generate the classes, i.e. for a lein project add `:aot [clj-jgit.diff]`
-(gen-class
-  :name clj-jgit.diff.Sequence
-  :extends org.eclipse.jgit.diff.Sequence
-  :state state
-  :init init
-  :prefix &quot;seq-&quot;
-  :constructors {[java.util.List] []}
-  :methods [[get [Integer] Object]])
-(defn seq-init
-  [s]
-  [[List] s])
-(defn seq-size [this]
-  (count (.state this)))
-(defn seq-get [this i]
-  (nth (.state this) i))
-(gen-class
-  :name clj-jgit.diff.SequenceComparator
-  :extends org.eclipse.jgit.diff.SequenceComparator
-  :prefix &quot;seq-comp-&quot;)
-(defn seq-comp-equals [_this col-a index-a col-b index-b]
-  (= (.get col-a index-a)
-     (.get col-b index-b)))
-(defn seq-comp-hash [_this col index]
-  (.hashCode (.get col index)))
-(defn diff-seq
-  ^EditList [a b]
-  (-&gt; (HistogramDiff.)
-      (.diff (SequenceComparator.) (Sequence. a) (Sequence. b)))))</pre></td></tr><tr><td class="spacer docs">&nbsp;</td><td class="codes" /></tr><tr><td class="docs"><div class="docs-header"><a class="anchor" href="#clj-jgit.querying" name="clj-jgit.querying"><h1 class="project-name">clj-jgit.querying</h1><a class="toc-link" href="#toc">toc</a></a></div></td><td class="codes" /></tr><tr><td class="docs">
+</td><td class="codes"><pre class="brush: clojure">(defn person-ident
+  [^PersonIdent person &amp; {:keys [java-time]}]
+  (when person
+    {:name     (.getName person)
+     :email    (.getEmailAddress person)
+     :date     (if java-time (.getWhenAsInstant person) (.getWhen person))
+     :timezone (if java-time (.getZoneId person) (.getTimeZone person))}))</pre></td></tr><tr><td class="spacer docs">&nbsp;</td><td class="codes" /></tr><tr><td class="docs"><div class="docs-header"><a class="anchor" href="#clj-jgit.querying" name="clj-jgit.querying"><h1 class="project-name">clj-jgit.querying</h1><a class="toc-link" href="#toc">toc</a></a></div></td><td class="codes" /></tr><tr><td class="docs">
 </td><td class="codes"><pre class="brush: clojure">(ns clj-jgit.querying
   (:require [clojure.string :as string]
             #_{:clj-kondo/ignore [:refer-all]}
@@ -3184,66 +3121,7 @@ net.brehaut.ClojureTools = (function (SH) {
         (add-branch-to-map repo rev-walk branch m)
         (if branches
           (recur branches)
-          m)))))</pre></td></tr><tr><td class="spacer docs">&nbsp;</td><td class="codes" /></tr><tr><td class="docs"><div class="docs-header"><a class="anchor" href="#clj-jgit.util" name="clj-jgit.util"><h1 class="project-name">clj-jgit.util</h1><a class="toc-link" href="#toc">toc</a></a></div></td><td class="codes" /></tr><tr><td class="docs">
-</td><td class="codes"><pre class="brush: clojure">(ns clj-jgit.util
-  (:require [clojure.java.io :as io])
-  (:import (java.io IOException)
-           (org.eclipse.jgit.internal.storage.file RefDirectory$LooseRef)
-           (org.eclipse.jgit.lib PersonIdent)))</pre></td></tr><tr><td class="docs"><p>Delete file <code>f</code>. If <code>f</code> is a directory, recursively deletes all files and directories within the directory. Raises an
-  exception if it fails, unless <code>silently</code> is true.</p>
-</td><td class="codes"><pre class="brush: clojure">(defn recursive-delete-file
-  [f &amp; [silently]]
-  (let [file (io/file f)]
-    (if (.exists file)
-      (do (doseq [child (reverse (file-seq file))]
-            (io/delete-file child silently))
-          true)
-      (or silently
-          (throw (IOException. (str &quot;Couldn't find &quot; f)))))))</pre></td></tr><tr><td class="docs"><p>If given <code>obj</code> isn't sequential? returns a vec with <code>obj</code> as single element, else just returns it's input.</p>
-</td><td class="codes"><pre class="brush: clojure">(defn seq?!
-  [obj]
-  (if (sequential? obj) obj (vector obj)))</pre></td></tr><tr><td class="docs"><p>Repeatedly executes function <code>f</code> for each entry in <code>param-seq</code>. The function is passed the <code>cmd-instance</code> as first
-  arg and a single <code>param-seq</code> entry as second arg. If <code>param-seq</code> isn't sequential? it's wrapped into a vector.
-  Returns given <code>cmd-instance</code>.</p>
-
-<p>  Example that executes <code>.addFilepattern</code> on a JGit AddCommand instance for each given file, nicely threaded:</p>
-
-<pre><code>  (-&gt; (.add repo)
-    (doseq-cmd-fn! #(.addFilepattern ^AddCommand %1 %2) ["file1.txt" "file2.txt"])
-    (.call))
-</code></pre>
-</td><td class="codes"><pre class="brush: clojure">(defn doseq-cmd-fn!
-  [cmd-instance f param-seq]
-    (doseq [p (seq?! param-seq)]
-      (f cmd-instance p))
-    cmd-instance)</pre></td></tr><tr><td class="docs"><p>Given a URI to a Git resource, derive the name (for use in cloning to a directory)</p>
-</td><td class="codes"><pre class="brush: clojure">(defn name-from-uri
-  [uri]
-  (second (re-find #&quot;/([^/]*)\.git$&quot; uri)))</pre></td></tr><tr><td class="docs"><p>Special <code>when</code> macro for checking if an attribute isn't available or is an empty string</p>
-</td><td class="codes"><pre class="brush: clojure">(defmacro when-present
-  [obj &amp; body]
-  `(when (not (or (nil? ~obj) (empty? ~obj)))
-     ~@body))</pre></td></tr><tr><td class="docs">
-</td><td class="codes"><pre class="brush: clojure">(defmethod print-method RefDirectory$LooseRef
-  [^RefDirectory$LooseRef o w]
-  (print-simple
-    (str &quot;#&lt;&quot; (.replaceFirst (str (.getClass o)) &quot;class &quot; &quot;&quot;) &quot;, &quot;
-         &quot;Name: &quot; (.getName o) &quot;, &quot;
-         &quot;ObjectId: &quot; (.getName (.getObjectId o)) &quot;&gt;&quot;) w))</pre></td></tr><tr><td class="docs"><p>Removes a leading slash from a path</p>
-</td><td class="codes"><pre class="brush: clojure">(defn normalize-path
-  [path]
-  (if (= path &quot;/&quot;)
-    &quot;/&quot;
-    (if (= (first path) \/)
-      (subs path 1)
-      path)))</pre></td></tr><tr><td class="docs"><p>Convert given JGit <code>PersonIdent</code> object into a map</p>
-</td><td class="codes"><pre class="brush: clojure">(defn person-ident
-  [^PersonIdent person]
-  (when person
-    {:name     (.getName person)
-     :email    (.getEmailAddress person)
-     :date     (.getWhen person)
-     :timezone (.getTimeZone person)}))</pre></td></tr><tr><td class="spacer docs">&nbsp;</td><td class="codes" /></tr><tr><td class="docs"><div class="docs-header"><a class="anchor" href="#clj-jgit.internal" name="clj-jgit.internal"><h1 class="project-name">clj-jgit.internal</h1><a class="toc-link" href="#toc">toc</a></a></div></td><td class="codes" /></tr><tr><td class="docs">
+          m)))))</pre></td></tr><tr><td class="spacer docs">&nbsp;</td><td class="codes" /></tr><tr><td class="docs"><div class="docs-header"><a class="anchor" href="#clj-jgit.internal" name="clj-jgit.internal"><h1 class="project-name">clj-jgit.internal</h1><a class="toc-link" href="#toc">toc</a></a></div></td><td class="codes" /></tr><tr><td class="docs">
 </td><td class="codes"><pre class="brush: clojure">(ns clj-jgit.internal
   (:import
     (clojure.lang Sequential)
@@ -3895,6 +3773,11 @@ Create a new tracking branch for a remote branch and make it the current branch:
 :author             A map of format {:name "me" :email "me@foo.net"}. If no
                     author is explicitly specified the author will be set to the
                     committer or to the original author when amending. (default: nil)
+                    Optional, but must be specified together as follows:
+                      :date              :timezone
+                      java.util.Date     java.util.TimeZone
+                      java.time.Instant  java.time.ZoneId
+                      Long               Integer
 :committer          A map of format {:name "me" :email "me@foo.net"}. If no
                     committer is explicitly specified the committer will be deduced
                     from config info in current repository, with current time.
@@ -3946,7 +3829,7 @@ Create a new tracking branch for a remote branch and make it the current branch:
           (.setAllowEmpty cmd allow-empty?)
           (.setAmend cmd amend?)
           (if (some? author)
-            (.setAuthor cmd (:name author) (:email author)) cmd)
+            (.setAuthor cmd (util/map-&gt;person-ident author)) cmd)
           (if (some? committer)
             (.setCommitter cmd (:name committer) (:email committer)) cmd)
           (.setInsertChangeId cmd insert-change-id?)
@@ -5149,7 +5032,146 @@ strategy        Keyword that sets the merge strategy to use during this update
   (as-&gt; (git-notes-show repo :ref ref) $
         (conj $ message)
         (str/join &quot;\n&quot; $)
-        (git-notes-add repo $ :ref ref :commit commit)))</pre></td></tr><tr><td class="spacer docs">&nbsp;</td><td class="codes" /></tr></table><div class="footer">Generated by <a href="https://github.com/gdeer81/marginalia">Marginalia</a>.&nbsp;&nbsp;Syntax highlighting provided by Alex Gorbatchev's <a href="http://alexgorbatchev.com/SyntaxHighlighter/">SyntaxHighlighter</a><div id="floating-toc"><ul><li class="floating-toc-li" id="floating-toc_clj-jgit.diff">clj-jgit.diff</li><li class="floating-toc-li" id="floating-toc_clj-jgit.querying">clj-jgit.querying</li><li class="floating-toc-li" id="floating-toc_clj-jgit.util">clj-jgit.util</li><li class="floating-toc-li" id="floating-toc_clj-jgit.internal">clj-jgit.internal</li><li class="floating-toc-li" id="floating-toc_clj-jgit.porcelain">clj-jgit.porcelain</li></ul></div></div><script type="text/javascript">SyntaxHighlighter.defaults['gutter'] = false;
+        (git-notes-add repo $ :ref ref :commit commit)))</pre></td></tr><tr><td class="spacer docs">&nbsp;</td><td class="codes" /></tr><tr><td class="docs"><div class="docs-header"><a class="anchor" href="#clj-jgit.diff" name="clj-jgit.diff"><h1 class="project-name">clj-jgit.diff</h1><a class="toc-link" href="#toc">toc</a></a></div></td><td class="codes" /></tr><tr><td class="docs">
+</td><td class="codes"><pre class="brush: clojure">(ns clj-jgit.diff
+  (:import (java.io ByteArrayOutputStream OutputStream)
+           (java.util List)
+           (org.eclipse.jgit.diff DiffFormatter EditList HistogramDiff RawText RawTextComparator)
+           (org.eclipse.jgit.treewalk.filter TreeFilter)))</pre></td></tr><tr><td class="docs">
+</td><td class="codes"><pre class="brush: clojure">(defonce raw-text-comparator-modes {:default            RawTextComparator/DEFAULT            ; No special treatment
+                                    :ws-ignore-all      RawTextComparator/WS_IGNORE_ALL      ; Ignores all whitespace
+                                    :ws-ignore-leading  RawTextComparator/WS_IGNORE_LEADING  ; Ignore leading whitespace
+                                    :ws-ignore-trailing RawTextComparator/WS_IGNORE_TRAILING ; Ignores trailing whitespace
+                                    :ws-ignore-change   RawTextComparator/WS_IGNORE_CHANGE}) ; Ignores whitespace occurring between non-whitespace characters</pre></td></tr><tr><td class="docs"><p>Returns a new <code>org.eclipse.jgit.diff.RawText</code> instance for given string <code>s</code></p>
+</td><td class="codes"><pre class="brush: clojure">(defn get-raw-text
+  ^RawText [^String s]
+  (-&gt; s .getBytes RawText.))</pre></td></tr><tr><td class="docs"><p>Compare given <code>RawText</code> instances <code>a</code> and <code>b</code>, returns a new <code>org.eclipse.jgit.diff.EditList</code> instance</p>
+</td><td class="codes"><pre class="brush: clojure">(defn diff-raw-text
+  ^EditList [a b &amp; {:keys [comparator-mode] :or {comparator-mode :default}}]
+  (let [comparator (comparator-mode raw-text-comparator-modes)]
+    (-&gt; (HistogramDiff.)
+        (.diff comparator a b))))</pre></td></tr><tr><td class="docs"><p>Compare given strings <code>a</code> and <code>b</code>, returns a new <code>org.eclipse.jgit.diff.EditList</code> instance</p>
+</td><td class="codes"><pre class="brush: clojure">(defn diff-string
+  ^EditList [a b &amp; {:keys [comparator-mode] :or {comparator-mode :default}}]
+  (diff-raw-text (get-raw-text a) (get-raw-text b) :comparator-mode comparator-mode))</pre></td></tr><tr><td class="docs"><p>Returns a new <code>org.eclipse.jgit.diff.DiffFormatter</code> instance. Note that depending on the used <code>format</code> method some
+  options are ignored, i.e. setting a <code>prefix</code> or <code>path-filter</code> has no effect when formatting raw-text-diffs.</p>
+
+<pre><code>Options:
+:abbreviation-length    `integer` that sets the number of digits to show for commit-ids.
+                        (default: 7)
+:binary-file-threshold  `integer` that sets the maximum file size for text files, in bytes.
+                        Files larger than this size will be assumed to be binary, even if they aren't.
+                        (default: 52428800)
+:context-lines          `integer` that sets the number of lines of context shown before and after a modification.
+                        (default: 3)
+:detect-renames?        `boolean` that sets rename detection. Ignored if `repository` is not set. Once enabled the
+                        detector can be configured away from its defaults by obtaining the instance directly by
+                        invoking `getRenameDetector()` on the formatter instance. Ignored when `:repository` is nil.
+                        (default: false)
+:monitor                Set a progress monitor. See JGit ProgressMonitor interface.
+                        (default: nil)
+:output-stream          The `OutputStream` instance the formatted diff is written to.
+                        (default: (ByteArrayOutputStream.))
+:path-filter            An `org.eclipse.jgit.treewalk.filter.TreeFilter` instance that limits the result, i.e.:
+                        `(PathFilter/create "project.clj")`. See `org.eclipse.jgit.treewalk.filter` namespace
+                        for all available filters or implement your own.
+                        (default: PathFilter/ALL)
+:prefix-new             A purely cosmetic `string` used as path prefix for the new side in the output. Can be empty
+                        but not nil.
+                        (default: "b/")
+:prefix-old             A purely cosmetic `string` used as path prefix for the old side in the output. Can be empty
+                        but not nil.
+                        (default: "a/")
+:quote-paths?           `boolean` that sets whether path names should be quoted. By default, the setting of
+                        `git config core.quotePath` is used. Ignored when `:repository` is nil.
+:repository             `Repository` instance the formatter can load object contents from. Once a repository has
+                        been set, the formatter must be released to ensure the internal ObjectReader is able to
+                        release its resources.
+                        (default: nil)
+</code></pre>
+</td><td class="codes"><pre class="brush: clojure">(defn get-diff-formatter
+  ^DiffFormatter [&amp; {:keys [abbreviation-length binary-file-threshold context-lines detect-renames? monitor
+                            output-stream path-filter quote-paths? repository]
+                     :or   {abbreviation-length   7
+                            binary-file-threshold 52428800
+                            context-lines         3
+                            detect-renames?       nil
+                            monitor               nil
+                            output-stream         (ByteArrayOutputStream.)
+                            path-filter           TreeFilter/ALL
+                            quote-paths?          nil
+                            repository            nil}}]
+  (let [formatter (doto (DiffFormatter. output-stream)
+                    (.setAbbreviationLength abbreviation-length)
+                    (.setBinaryFileThreshold binary-file-threshold)
+                    (.setContext context-lines)
+                    (.setProgressMonitor monitor)
+                    (.setPathFilter path-filter))]
+    (when repository
+      (.setRepository formatter repository)
+      (when (some? detect-renames?) (.setDetectRenames formatter detect-renames?))
+      (when (some? quote-paths?) (.setQuotePaths formatter quote-paths?)))
+    formatter))</pre></td></tr><tr><td class="docs"><p>Compare given strings <code>a</code> and <code>b</code> and write a patch-style formatted string to given <code>:output-stream</code>. Always returns
+  the <code>output-stream</code>.</p>
+
+<p>  Options:</p>
+
+<p>  :comparator-mode  Keyword that sets how whitespace changes are handled:
+                      <code>:ws-ignore-all</code>      Ignores all whitespace
+                      <code>:ws-ignore-leading</code>  Ignore leading whitespace
+                      <code>:ws-ignore-trailing</code> Ignores trailing whitespace
+                      <code>:ws-ignore-change</code>   Ignores whitespace occurring between non-whitespace characters
+                      <code>:default</code>            No special treatment
+  :context-lines    <code>integer</code> that sets the number of lines of context shown before and after a modification.
+                    (default: 3)
+  :output-stream    The <code>OutputStream</code> instance the formatted diff is written to. Note that the returned stream is not
+                    flushed or closed, when in doubt use <code>with-open</code>.
+                    (default: (ByteArrayOutputStream.))</p>
+</td><td class="codes"><pre class="brush: clojure">(defn diff-string-formatted
+  ^OutputStream [a b &amp; {:keys [comparator-mode context-lines output-stream]
+                        :or   {comparator-mode :default
+                               context-lines    3
+                               output-stream   (ByteArrayOutputStream.)}}]
+  (let [raw-a (get-raw-text a)
+        raw-b (get-raw-text b)
+        edit-list (diff-raw-text raw-a raw-b :comparator-mode comparator-mode)]
+    (-&gt; (get-diff-formatter :output-stream output-stream :context-lines context-lines)
+        (.format edit-list raw-a raw-b))
+    output-stream))</pre></td></tr><tr><td class="docs"><p>Set internal <code>state</code> field to given seq <code>s</code>Compare given sequences <code>a</code> and <code>b</code>, returns a new <code>org.eclipse.jgit.diff.EditList</code> instance</p>
+</td><td class="codes"><pre class="brush: clojure">#_{:clj-kondo/ignore [:unresolved-symbol]}
+(comment
+  ; JGit also supports diffing of sequences, subsequences and hashed sequences. Each type requires prior implementation of
+  ; its abstract classes, see https://download.eclipse.org/jgit/site/6.0.0.202111291000-r/apidocs/org/eclipse/jgit/diff/package-summary.html
+  ; Simple example for diffing Sequences below, sadly `proxy` and `reify` don't support adding new methods to abstract classes.
+  ; Note: requires aot compilation to generate the classes, i.e. for a lein project add `:aot [clj-jgit.diff]`
+(gen-class
+  :name clj-jgit.diff.Sequence
+  :extends org.eclipse.jgit.diff.Sequence
+  :state state
+  :init init
+  :prefix &quot;seq-&quot;
+  :constructors {[java.util.List] []}
+  :methods [[get [Integer] Object]])
+(defn seq-init
+  [s]
+  [[List] s])
+(defn seq-size [this]
+  (count (.state this)))
+(defn seq-get [this i]
+  (nth (.state this) i))
+(gen-class
+  :name clj-jgit.diff.SequenceComparator
+  :extends org.eclipse.jgit.diff.SequenceComparator
+  :prefix &quot;seq-comp-&quot;)
+(defn seq-comp-equals [_this col-a index-a col-b index-b]
+  (= (.get col-a index-a)
+     (.get col-b index-b)))
+(defn seq-comp-hash [_this col index]
+  (.hashCode (.get col index)))
+(defn diff-seq
+  ^EditList [a b]
+  (-&gt; (HistogramDiff.)
+      (.diff (SequenceComparator.) (Sequence. a) (Sequence. b)))))</pre></td></tr><tr><td class="spacer docs">&nbsp;</td><td class="codes" /></tr></table><div class="footer">Generated by <a href="https://github.com/gdeer81/marginalia">Marginalia</a>.&nbsp;&nbsp;Syntax highlighting provided by Alex Gorbatchev's <a href="http://alexgorbatchev.com/SyntaxHighlighter/">SyntaxHighlighter</a><div id="floating-toc"><ul><li class="floating-toc-li" id="floating-toc_clj-jgit.util">clj-jgit.util</li><li class="floating-toc-li" id="floating-toc_clj-jgit.querying">clj-jgit.querying</li><li class="floating-toc-li" id="floating-toc_clj-jgit.internal">clj-jgit.internal</li><li class="floating-toc-li" id="floating-toc_clj-jgit.porcelain">clj-jgit.porcelain</li><li class="floating-toc-li" id="floating-toc_clj-jgit.diff">clj-jgit.diff</li></ul></div></div><script type="text/javascript">SyntaxHighlighter.defaults['gutter'] = false;
 SyntaxHighlighter.all();
 
 // hackity hack

--- a/src/clj_jgit/porcelain.clj
+++ b/src/clj_jgit/porcelain.clj
@@ -616,6 +616,11 @@
     :author             A map of format {:name \"me\" :email \"me@foo.net\"}. If no
                         author is explicitly specified the author will be set to the
                         committer or to the original author when amending. (default: nil)
+                        Optional, but must be specified together as follows:
+                          :date              :timezone
+                          java.util.Date     java.util.TimeZone
+                          java.time.Instant  java.time.ZoneId
+                          Long               Integer
     :committer          A map of format {:name \"me\" :email \"me@foo.net\"}. If no
                         committer is explicitly specified the committer will be deduced
                         from config info in current repository, with current time.
@@ -666,7 +671,7 @@
           (.setAllowEmpty cmd allow-empty?)
           (.setAmend cmd amend?)
           (if (some? author)
-            (.setAuthor cmd (:name author) (:email author)) cmd)
+            (.setAuthor cmd (util/map->person-ident author)) cmd)
           (if (some? committer)
             (.setCommitter cmd (:name committer) (:email committer)) cmd)
           (.setInsertChangeId cmd insert-change-id?)

--- a/src/clj_jgit/util.clj
+++ b/src/clj_jgit/util.clj
@@ -64,11 +64,30 @@
       (subs path 1)
       path)))
 
+(defn map->person-ident
+  "Construct a JGit `PersonIdent` object from a map"
+  ^PersonIdent
+  [{:keys [name email date timezone]}]
+  ;; if one is specified but not the other, PersonIdent constructor will fail
+  (if (or (some? date) (some? timezone))
+    (PersonIdent. ^String name ^String email date timezone)
+    (PersonIdent. ^String name ^String email)))
+
 (defn person-ident
-  "Convert given JGit `PersonIdent` object into a map"
-  [^PersonIdent person]
+  "Convert given JGit `PersonIdent` object into a map.
+   
+    Options:
+   
+    :java-time  Use java.time objects for :date and :timezone.
+                  :date      java.time.Instant
+                  :timezone  java.time.ZoneId
+                (default: nil)
+                  :date      java.util.Date
+                  :timezone  java.util.TimeZone
+   "
+  [^PersonIdent person & {:keys [java-time]}]
   (when person
     {:name     (.getName person)
      :email    (.getEmailAddress person)
-     :date     (.getWhen person)
-     :timezone (.getTimeZone person)}))
+     :date     (if java-time (.getWhenAsInstant person) (.getWhen person))
+     :timezone (if java-time (.getZoneId person) (.getTimeZone person))}))

--- a/test/clj_jgit/test/porcelain.clj
+++ b/test/clj_jgit/test/porcelain.clj
@@ -7,7 +7,10 @@
     (org.eclipse.jgit.api.errors NoHeadException)
     (org.eclipse.jgit.revwalk RevWalk RevCommit)
     (org.eclipse.jgit.transport PushResult URIish)
-    (org.eclipse.jgit.lib ObjectId StoredConfig)))
+    (org.eclipse.jgit.lib ObjectId StoredConfig)
+    (java.time Instant ZoneId)
+    (java.time.temporal ChronoUnit))
+  (:require [clj-jgit.util :as util]))
 
 (deftest test-git-init
   (let [repo-dir (get-temp-dir)]
@@ -25,6 +28,22 @@
     (read-only-repo
       (is (instance? Git repo))
       (is (instance? RevWalk rev-walk)))))
+
+(deftest test-git-commit
+  (with-tmp-repo "target/tmp"
+    (let [author {:name "me"
+                  :email "me@foo.net"
+                  :date (.minusSeconds (Instant/now) 60)
+                  :timezone (ZoneId/systemDefault)}
+          commit (git-commit repo "initial commit" {:author author})]
+      (testing "git-commit with custom author date"
+        (is (instance? RevCommit commit)))
+      (testing "git-commit keeps custom author date"
+        (let [normalize (fn [person-ident] (-> person-ident
+                                               (update :date #(.truncatedTo % ChronoUnit/SECONDS))
+                                               (update :timezone #(.getOffset (.getRules %) (:date person-ident)))))]
+          (is (= (normalize author)
+                 (normalize (util/person-ident (.getAuthorIdent commit) :java-time true)))))))))
 
 (deftest test-git-config-functions
   (with-tmp-repo "target/tmp"


### PR DESCRIPTION
JGit supports setting the commit author date, similar to `git commit --date=<date>`.

This PR enables that with clj-jgit using optional `:date` and `:timezone` keys on `git-commit`'s `:author` map argument.